### PR TITLE
template does not deploy with discovery job as is

### DIFF
--- a/.templates/aws/resource-pools.yml
+++ b/.templates/aws/resource-pools.yml
@@ -6,12 +6,6 @@ resource_pools:
     cloud_properties:
       instance_type: m3.medium
 
-  - name: discovery
-    network: concourse
-    stemcell: (( grab meta.stemcell ))
-    cloud_properties:
-      instance_type: m3.medium
-
   - name: db
     network: concourse
     stemcell: (( grab meta.stemcell ))
@@ -40,8 +34,6 @@ compilation:
 jobs:
   - name: haproxy
     resource_pool: haproxy
-  - name: discovery
-    resource_pool: discovery
   - name: web
     resource_pool: web
   - name: db


### PR DESCRIPTION
When trying to deploy on AWS, the discovery job is incomplete as is.  We need to either remove for now or refactor and finish the parts we need for it to work in the template.
